### PR TITLE
Use a PEP 440 compliant version number

### DIFF
--- a/dmark/__init__.py
+++ b/dmark/__init__.py
@@ -1,7 +1,7 @@
 import string
 import itertools
 
-__version__ = "not yet, not yet"
+__version__ = "0.dev0"
 
 
 class ParserError(Exception):


### PR DESCRIPTION
Before this change, `python -m build` would give the following warning…

    ********************************************************************************
    Version 'not yet, not yet' is not valid according to PEP 440.

    Please make sure to specify a valid version for your package.
    Also note that future releases of setuptools may halt the build process
    if an invalid version is given.

    By 2023-Sep-26, you need to update your project and remove deprecated calls
    or your builds will no longer be supported.

    See https://peps.python.org/pep-0440/ for details.
    ********************************************************************************

…and then crash with the following exception:

    setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'not.yet-.not.yet'

The version “0.dev0” was chosen because it’s short and conveys a similar
message to “not yet, not yet”.

---

Specifically, that exception was preventing me from building [resholve](https://github.com/abathur/resholve
).
